### PR TITLE
Handle double quoted patterns

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,9 +22,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up JDK
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: 11
         distribution: adopt
@@ -53,19 +53,19 @@ jobs:
       with:
         files: yang-lsp/**/test-results/**/*.xml
     - name: Archive yang-language-server
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: yang-language-server_${{ env.PROJECT_VERSION }}
         path: |
           yang-lsp/build/yang-language-server_[0-9]*.zip
     - name: Archive yang-language-server_diagram-extension
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: yang-language-server_diagram-extension_${{ env.PROJECT_VERSION }}
         path: |
           yang-lsp/build/yang-language-server_diagram-extension*.zip
     - name: Archive yang-tool_cli
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: yang-tool_cli_${{ env.PROJECT_VERSION }}
         path: |

--- a/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/YangValueConverterService.xtend
+++ b/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/YangValueConverterService.xtend
@@ -40,13 +40,44 @@ class YangValueConverterService extends AbstractDeclarativeValueConverterService
 				if (!n.hidden) {
 					val seg = n.text
 					if (isQuoted(seg)) {
-						result.append(seg.substring(1, seg.length-1))
+						val inner = seg.substring(1, seg.length-1)
+						if (seg.startsWith("\"")) {
+							result.append(unescapeYangDoubleQuoted(inner))
+						} else {
+							result.append(inner)
+						}
 					} else {
 						result.append(seg)
 					}
 				}
 			}
 			return result.toString
+		}
+		
+		/**
+		 * Process YANG double-quoted string escape sequences per RFC 7950 Section 6.1.3.
+		 */
+		def static String unescapeYangDoubleQuoted(String s) {
+			val bsIndex = s.indexOf('\\')
+			if (bsIndex < 0) return s
+			val sb = new StringBuilder(s.length)
+			sb.append(s, 0, bsIndex)
+			var i = bsIndex
+			while (i < s.length) {
+				val c = s.charAt(i)
+				if (c === 0x5C && i + 1 < s.length) {
+					val next = s.charAt(i + 1)
+					if (next === 0x6E) { sb.append('\n'); i += 2 }
+					else if (next === 0x74) { sb.append('\t'); i += 2 }
+					else if (next === 0x22) { sb.append('"'); i += 2 }
+					else if (next === 0x5C) { sb.append('\\'); i += 2 }
+					else { sb.append(c); i++ }
+				} else {
+					sb.append(c)
+					i++
+				}
+			}
+			return sb.toString
 		}
 		
 		def static boolean isQuoted(String text) {

--- a/yang-lsp/io.typefox.yang/src/test/java/io/typefox/yang/tests/validation/RegexpTest.xtend
+++ b/yang-lsp/io.typefox.yang/src/test/java/io/typefox/yang/tests/validation/RegexpTest.xtend
@@ -46,6 +46,26 @@ class RegexpTest extends AbstractYangTest {
 		assertNoErrors(foo.allContents.filter(Pattern).head, TYPE_ERROR)
 	}
 	
+	@Test def void testIssue239() {
+		val foo = load('''
+			module foo {
+			    yang-version 1.1;
+			    namespace urn:ietf:params:xml:ns:yang:foo;
+			    prefix foo;
+			
+			    	typedef foo {
+					type string  {
+						pattern "[a-zA-Z0-9!$%\\^()\\[\\]_\\-~{}.+]*";
+					}
+				}
+			}
+		''')
+		val p = foo.allContents.filter(Pattern).head
+		System.out.println("Issue 239 regexp value: [" + p.regexp + "]")
+		validator.validate(foo)
+		assertNoErrors(p, TYPE_ERROR)
+	}
+	
 	@Test def void testIllegalPattern_0() {
 		val foo = load('''
 			module foo {


### PR DESCRIPTION
This addresses TypeFox/yang-lsp#239

https://xerces.apache.org/xerces2-j/javadocs/xerces2/org/apache/xerces/impl/xpath/regex/RegularExpression.html used by yang-lsp expects W3C pattern which is single quoted, whereas YANG double quoted syntax includes escaped backslashes `\\` which need to be unescaped before passing to W3C pattern regex handler.