### PR TITLE
fix crash when experiencing max-elements input error

### DIFF
--- a/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/validation/YangValidator.xtend
+++ b/yang-lsp/io.typefox.yang/src/main/java/io/typefox/yang/validation/YangValidator.xtend
@@ -402,7 +402,7 @@ class YangValidator extends AbstractYangValidator {
 			val expectedElements = maxElements.parseIntSafe;
 			if (expectedElements === null || expectedElements.intValue < 1) {
 				val message = '''The value of the "max-elements" must be a positive integer or the string "unbounded".''';
-				error(message, it, MIN_ELEMENTS__MIN_ELEMENTS, TYPE_ERROR);
+				error(message, it, MAX_ELEMENTS__MAX_ELEMENTS, TYPE_ERROR);
 			}
 		}
 	}


### PR DESCRIPTION
I was receiving a java error when using yangster, i think i pinned it down to the right place, and this fix successfully compiles, but when i tried to test, the language server would spin up, freeze, and hog memory forever. 

Error executing EValidator: java.lang.IllegalArgumentException: The sources EClass 'MaxElements' does not expose the feature 'MinElements.minElements'

I think they are unrelated issues but thought i'd open a PR anyways. I am not familiar with xtend, so this PR may not include everything needed for this fix.